### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# This repository is owned by
+* @leanix/team-tornado


### PR DESCRIPTION
In context of [RFC 86](https://leanix.atlassian.net/wiki/spaces/RFCs/pages/7890698246/RFC+86+-+GitHub+teams+and+CODEOWNERS+file) it was agreed that we will no longer use repository topics to reflect the ownership of a repository but instead use Github's CODEOWNERS file. This pull request was created automatically by team :butterfly: to speed up the adoption while keeping the necessary manual steps minimal. If you have questions or need help to get this merged, please reach out: [#team-butterfly](https://leanix.slack.com/archives/C07SDFL8JCD)

---

**❗ACTION NEEDED❗**
If you see warnings to the CODEOWNERS file (`This CODEOWNERS file contains errors`) in this pull request make sure your team (not just the individual members) has write permissions to this repository.
This can be done by the repository admin. If you're not admin of this repository you need to create an IT ticket.

---

**Extra Steps for Mono Repos:**

If this is a mono repository owned by multiple teams, you might want to add another commit and assign specific files or directories to individual teams. Please refer to the [CODEOWNERS documentation](https://docs.github.com/en/enterprise-cloud@latest/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for more information.
